### PR TITLE
router.reset() url redirect

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -178,9 +178,10 @@ export class BrowserHistory extends History {
 
     fragment = this.getFragment(fragment || '');
 
-    if (this.fragment === fragment) {
-      return;
-    }
+    //removed. router.reset not routing to new url
+    //if (this.fragment === fragment) {
+    //  return;
+    //}
 
     this.fragment = fragment;
 


### PR DESCRIPTION
I have an issue where after authentication the router is reset and reconfigured. 
I then want to route to a new empty route, but the code exits at this point and the url is never loaded.
If there is a better way of doing this?  If so, please let me know.
