### PR TITLE
perf(index): change polling from setInterval to setTimeout

### DIFF
--- a/dist/amd/index.js
+++ b/dist/amd/index.js
@@ -103,7 +103,7 @@ define(['exports', 'core-js', 'aurelia-history'], function (exports, _coreJs, _a
         } else if (this._wantsHashChange && 'onhashchange' in window) {
           window.addEventListener('hashchange', this._checkUrlCallback);
         } else if (this._wantsHashChange) {
-          this._checkUrlInterval = setInterval(this._checkUrlCallback, this.interval);
+          this._checkUrlTimer = setTimeout(this._checkUrlCallback, this.interval);
         }
 
         this.fragment = fragment;
@@ -132,13 +132,18 @@ define(['exports', 'core-js', 'aurelia-history'], function (exports, _coreJs, _a
       value: function deactivate() {
         window.onpopstate = null;
         window.removeEventListener('hashchange', this._checkUrlCallback);
-        clearInterval(this._checkUrlInterval);
+        clearTimeout(this._checkUrlTimer);
         this.active = false;
       }
     }, {
       key: 'checkUrl',
       value: function checkUrl() {
         var current = this.getFragment();
+
+        if (this._checkUrlTimer) {
+          clearTimeout(this._checkUrlTimer);
+          this._checkUrlTimer = setTimeout(this._checkUrlCallback, this.interval);
+        }
 
         if (current === this.fragment && this.iframe) {
           current = this.getFragment(this.getHash(this.iframe));

--- a/dist/commonjs/index.js
+++ b/dist/commonjs/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _interopRequireWildcard = function (obj) { return obj && obj.__esModule ? obj : { 'default': obj }; };
+var _interopRequireDefault = function (obj) { return obj && obj.__esModule ? obj : { 'default': obj }; };
 
 var _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } };
 
@@ -17,7 +17,7 @@ exports.install = install;
 
 var _core = require('core-js');
 
-var _core2 = _interopRequireWildcard(_core);
+var _core2 = _interopRequireDefault(_core);
 
 var _History2 = require('aurelia-history');
 
@@ -106,7 +106,7 @@ var BrowserHistory = (function (_History) {
       } else if (this._wantsHashChange && 'onhashchange' in window) {
         window.addEventListener('hashchange', this._checkUrlCallback);
       } else if (this._wantsHashChange) {
-        this._checkUrlInterval = setInterval(this._checkUrlCallback, this.interval);
+        this._checkUrlTimer = setTimeout(this._checkUrlCallback, this.interval);
       }
 
       this.fragment = fragment;
@@ -135,13 +135,18 @@ var BrowserHistory = (function (_History) {
     value: function deactivate() {
       window.onpopstate = null;
       window.removeEventListener('hashchange', this._checkUrlCallback);
-      clearInterval(this._checkUrlInterval);
+      clearTimeout(this._checkUrlTimer);
       this.active = false;
     }
   }, {
     key: 'checkUrl',
     value: function checkUrl() {
       var current = this.getFragment();
+
+      if (this._checkUrlTimer) {
+        clearTimeout(this._checkUrlTimer);
+        this._checkUrlTimer = setTimeout(this._checkUrlCallback, this.interval);
+      }
 
       if (current === this.fragment && this.iframe) {
         current = this.getFragment(this.getHash(this.iframe));

--- a/dist/es6/index.js
+++ b/dist/es6/index.js
@@ -90,7 +90,7 @@ export class BrowserHistory extends History {
     } else if (this._wantsHashChange && ('onhashchange' in window)) {
       window.addEventListener('hashchange', this._checkUrlCallback);
     } else if (this._wantsHashChange) {
-      this._checkUrlInterval = setInterval(this._checkUrlCallback, this.interval);
+      this._checkUrlTimer = setTimeout(this._checkUrlCallback, this.interval);
     }
 
     // Determine if we need to change the base url, for a pushState link
@@ -126,12 +126,17 @@ export class BrowserHistory extends History {
   deactivate() {
     window.onpopstate = null;
     window.removeEventListener('hashchange', this._checkUrlCallback);
-    clearInterval(this._checkUrlInterval);
+    clearTimeout(this._checkUrlTimer);
     this.active = false;
   }
 
   checkUrl() {
     var current = this.getFragment();
+    
+    if (this._checkUrlTimer) {
+        clearTimeout(this._checkUrlTimer);
+        this._checkUrlTimer = setTimeout(this._checkUrlCallback, this.interval);
+    }
 
     if (current === this.fragment && this.iframe) {
       current = this.getFragment(this.getHash(this.iframe));

--- a/dist/system/index.js
+++ b/dist/system/index.js
@@ -106,7 +106,7 @@ System.register(['core-js', 'aurelia-history'], function (_export) {
             } else if (this._wantsHashChange && 'onhashchange' in window) {
               window.addEventListener('hashchange', this._checkUrlCallback);
             } else if (this._wantsHashChange) {
-              this._checkUrlInterval = setInterval(this._checkUrlCallback, this.interval);
+              this._checkUrlTimer = setTimeout(this._checkUrlCallback, this.interval);
             }
 
             this.fragment = fragment;
@@ -135,13 +135,18 @@ System.register(['core-js', 'aurelia-history'], function (_export) {
           value: function deactivate() {
             window.onpopstate = null;
             window.removeEventListener('hashchange', this._checkUrlCallback);
-            clearInterval(this._checkUrlInterval);
+            clearTimeout(this._checkUrlTimer);
             this.active = false;
           }
         }, {
           key: 'checkUrl',
           value: function checkUrl() {
             var current = this.getFragment();
+
+            if (this._checkUrlTimer) {
+              clearTimeout(this._checkUrlTimer);
+              this._checkUrlTimer = setTimeout(this._checkUrlCallback, this.interval);
+            }
 
             if (current === this.fragment && this.iframe) {
               current = this.getFragment(this.getHash(this.iframe));

--- a/src/index.js
+++ b/src/index.js
@@ -90,7 +90,7 @@ export class BrowserHistory extends History {
     } else if (this._wantsHashChange && ('onhashchange' in window)) {
       window.addEventListener('hashchange', this._checkUrlCallback);
     } else if (this._wantsHashChange) {
-      this._checkUrlInterval = setInterval(this._checkUrlCallback, this.interval);
+      this._checkUrlTimer = setTimeout(this._checkUrlCallback, this.interval);
     }
 
     // Determine if we need to change the base url, for a pushState link
@@ -126,12 +126,17 @@ export class BrowserHistory extends History {
   deactivate() {
     window.onpopstate = null;
     window.removeEventListener('hashchange', this._checkUrlCallback);
-    clearInterval(this._checkUrlInterval);
+    clearTimeout(this._checkUrlTimer);
     this.active = false;
   }
 
   checkUrl() {
     var current = this.getFragment();
+    
+    if (this._checkUrlTimer) {
+        clearTimeout(this._checkUrlTimer);
+        this._checkUrlTimer = setTimeout(this._checkUrlCallback, this.interval);
+    }
 
     if (current === this.fragment && this.iframe) {
       current = this.getFragment(this.getHash(this.iframe));


### PR DESCRIPTION
If the UI or runtime gets bogged down on a long running task, interval callbacks can stack up.  When resources free up, the stack of callbacks execute immediately in succession, causing even more of a performance hit. For motivation, please read John Resig's writeup on timers: http://ejohn.org/blog/how-javascript-timers-work/
