### PR TITLE
fix(normalize-fragment): fix getFragment() to return normalized values

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import core from 'core-js';
 import {History} from 'aurelia-history';
 
 // Cached regex for stripping a leading hash/slash and trailing space.
-var routeStripper = /^[#\/]|\s+$/g;
+var routeStripper = /^#?\/*|\s+$/g;
 
 // Cached regex for stripping leading and trailing slashes.
 var rootStripper = /^\/+|\/+$/g;

--- a/test/history.spec.js
+++ b/test/history.spec.js
@@ -5,4 +5,24 @@ describe('browser history', () => {
     var bh = new BrowserHistory();
     expect(bh).toBe(bh);
   });
+
+  describe('getFragment()', () => {
+
+    it('should normalize fragment', () => {
+      var expected = 'admin/user/123';
+      var bh = new BrowserHistory();
+
+      expect(bh.getFragment('admin/user/123')).toBe(expected);
+      expect(bh.getFragment('admin/user/123  ')).toBe(expected);
+      expect(bh.getFragment('/admin/user/123')).toBe(expected);
+      expect(bh.getFragment('/admin/user/123   ')).toBe(expected);
+      expect(bh.getFragment('///admin/user/123')).toBe(expected);
+
+      expect(bh.getFragment('#admin/user/123')).toBe(expected);
+      expect(bh.getFragment('#admin/user/123  ')).toBe(expected);
+      expect(bh.getFragment('#/admin/user/123')).toBe(expected);
+      expect(bh.getFragment('#/admin/user/123   ')).toBe(expected);
+      expect(bh.getFragment('#///admin/user/123')).toBe(expected);
+    })
+  })
 });


### PR DESCRIPTION
Hi, i have fixed `routeStripper` regexp, so that `getFragment()` returns normalized fragment.

Problem was that 

``` js
getFragment(getFragment('#/admin/user')) !== getFragment('#/admin/user')
```

I run into this when I want to change route without triggering `loadUrl()`:

``` js
browserHistory.navigate('#/admin/user', false);
```

This was storing `this.fragment = '/admin/user'` but when the browser fired onhashchange `checkUrl()` run `loadUrl()` because `this.fragment !== this.getFragment()`
