### PR TITLE
fix(history): normalize fragments with a leading slash

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -65,7 +65,7 @@ export class BrowserHistory extends History {
       }
     }
 
-    return fragment.replace(routeStripper, '');
+    return '/' + fragment.replace(routeStripper, '');
   }
 
   activate(options) {

--- a/test/history.spec.js
+++ b/test/history.spec.js
@@ -9,7 +9,7 @@ describe('browser history', () => {
   describe('getFragment()', () => {
 
     it('should normalize fragment', () => {
-      var expected = 'admin/user/123';
+      var expected = '/admin/user/123';
       var bh = new BrowserHistory();
 
       expect(bh.getFragment('admin/user/123')).toBe(expected);


### PR DESCRIPTION
This isn't breaking anything, but it is inconsistent. We should use the leading slash because generated URLs are always absolute.

Fixes aurelia/router#125.
