### PR TITLE
fix(history): fixed regression issue which added double slashes to the pushState fragment

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -64,6 +64,11 @@ export class BrowserHistory extends History {
         fragment = this.getHash();
       }
     }
+    
+    // If fragment is already prefixed with a slash, don't add another
+    if (fragment.charAt(0) === '/') {
+      return fragment.replace(routeStripper, '');
+    }
 
     return '/' + fragment.replace(routeStripper, '');
   }

--- a/src/index.js
+++ b/src/index.js
@@ -64,11 +64,6 @@ export class BrowserHistory extends History {
         fragment = this.getHash();
       }
     }
-    
-    // If fragment is already prefixed with a slash, don't add another
-    if (fragment.charAt(0) === '/') {
-      return fragment.replace(routeStripper, '');
-    }
 
     return '/' + fragment.replace(routeStripper, '');
   }
@@ -208,6 +203,7 @@ export class BrowserHistory extends History {
 
     // If pushState is available, we use it to set the fragment as a real URL.
     if (this._hasPushState) {
+      url = url.replace('//', '/');
       this.history[options.replace ? 'replaceState' : 'pushState']({}, document.title, url);
 
       // If hash changes haven't been explicitly disabled, update the hash


### PR DESCRIPTION
The previous commit which introduced a forward slash in-front of url fragments causes double up with child routes. Not sure if this should go deeper, but the easiest solution is to check if the first character is a forward slash and if it is, then don't add another. References issue [#141](https://github.com/aurelia/router/issues/141) which was created on the Router component.
