### PR TITLE
fix(history-browser): Use correct import for core-js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import core from 'core-js';
+import * as core from 'core-js';
 import {History} from 'aurelia-history';
 
 // Cached regex for stripping a leading hash/slash and trailing space.


### PR DESCRIPTION
We were previously using `import core from core-js` which generates d.ts that do not match the corejs d.ts. This is now updated to `import * as core 'core-js'`, which resolves TypeScript compilation warnings.

closes aurelia/framework#177
