### PR TITLE
feat(history-browser): add getOrigin method

### DIFF
--- a/config.js
+++ b/config.js
@@ -16,9 +16,10 @@ System.config({
   map: {
     "aurelia-history": "npm:aurelia-history@1.0.0-beta.1.1.1",
     "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.1.1",
+    "aurelia-pal-browser": "npm:aurelia-pal-browser@1.0.0-beta.1.1.3",
     "babel": "npm:babel-core@5.1.13",
     "babel-runtime": "npm:babel-runtime@5.1.13",
-    "core-js": "npm:core-js@2.0.3",
+    "core-js": "npm:core-js@2.1.0",
     "github:jspm/nodelibs-assert@0.1.0": {
       "assert": "npm:assert@1.3.0"
     },
@@ -34,7 +35,11 @@ System.config({
     "npm:assert@1.3.0": {
       "util": "npm:util@0.10.3"
     },
-    "npm:core-js@2.0.3": {
+    "npm:aurelia-pal-browser@1.0.0-beta.1.1.3": {
+      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.1.1",
+      "core-js": "npm:core-js@2.1.0"
+    },
+    "npm:core-js@2.1.0": {
       "fs": "github:jspm/nodelibs-fs@0.1.2",
       "path": "github:jspm/nodelibs-path@0.1.0",
       "process": "github:jspm/nodelibs-process@0.1.2",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
       "aurelia-pal": "^1.0.0-beta.1.1.1"
     },
     "devDependencies": {
+      "aurelia-pal-browser": "^1.0.0-beta.1.1.3",
       "babel": "babel-core@^5.1.13",
       "babel-runtime": "^5.1.13",
       "core-js": "^2.0.3"

--- a/src/index.js
+++ b/src/index.js
@@ -108,6 +108,14 @@ export class BrowserHistory extends History {
   }
 
   /**
+   * Returns the fully-qualified root of the current history object.
+   */
+  getAbsoluteRoot(): string {
+    let origin = createOrigin(this.location.protocol, this.location.hostname, this.location.port);
+    return `${origin}${this.root}`;
+  }
+
+  /**
    * Causes a history navigation to occur.
    *
    * @param fragment The history fragment to navigate to.
@@ -234,4 +242,8 @@ function updateHash(location, fragment, replace) {
     // Some browsers require that `hash` contains a leading #.
     location.hash = '#' + fragment;
   }
+}
+
+function createOrigin(protocol: string, hostname: string, port: string) {
+  return `${protocol}//${hostname}${port ? ':' + port : ''}`;
 }

--- a/test/history.spec.js
+++ b/test/history.spec.js
@@ -1,4 +1,6 @@
+import './setup';
 import {BrowserHistory} from '../src/index';
+import {LinkHandler} from '../src/link-handler';
 
 describe('browser history', () => {
   it('should have some tests', () => {
@@ -23,6 +25,46 @@ describe('browser history', () => {
       expect(bh._getFragment('#/admin/user/123')).toBe(expected);
       expect(bh._getFragment('#/admin/user/123   ')).toBe(expected);
       expect(bh._getFragment('#///admin/user/123')).toBe(expected);
-    })
-  })
+    });
+  });
+
+  describe('getAbsoluteRoot', () => {
+    it('should return a valid URL with a trailing slash', () => {
+      var bh = new BrowserHistory(new LinkHandler());
+      bh.activate({});
+      bh.location = {
+        protocol: 'http:',
+        hostname: 'localhost',
+        port: ''
+      };
+
+      expect(bh.getAbsoluteRoot()).toBe('http://localhost/');
+    });
+
+    it('should return a valid URL with a port', () => {
+      var options = {};
+      var bh = new BrowserHistory(new LinkHandler());
+      bh.activate(options);
+      bh.location = {
+        protocol: 'https:',
+        hostname: 'www.aurelia.io',
+        port: '8080'
+      };
+
+      expect(bh.getAbsoluteRoot()).toBe('https://www.aurelia.io:8080/');
+    });
+
+    it('should return a valid URL with a trailing fragment if root is set', () => {
+      var options = { root: '/application/'}
+      var bh = new BrowserHistory(new LinkHandler());
+      bh.activate(options);
+      bh.location = {
+        protocol: 'https:',
+        hostname: 'www.aurelia.io',
+        port: '8080'
+      };
+
+      expect(bh.getAbsoluteRoot()).toBe('https://www.aurelia.io:8080/application/');
+    });
+  });
 });

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,2 @@
+import {initialize} from 'aurelia-pal-browser';
+initialize();


### PR DESCRIPTION
Per https://github.com/aurelia/router/issues/88 we want to be able to generate an absolute URI with the `router.generate()` method. That method relies upon the history module. `getOrigin` allows the router to generate an absolute URI with the protocol, hostname, and port.
