### PR TITLE
Allow clicks to bubble and respect defaultPrevented

### DIFF
--- a/src/link-handler.js
+++ b/src/link-handler.js
@@ -87,6 +87,10 @@ export class DefaultLinkHandler extends LinkHandler {
       anchor: null
     };
 
+    if (event.defaultPrevented) {
+      return info;
+    }
+
     let target = DefaultLinkHandler.findClosestAnchor(event.target);
     if (!target || !DefaultLinkHandler.targetIsThisWindow(target)) {
       return info;

--- a/src/link-handler.js
+++ b/src/link-handler.js
@@ -64,7 +64,7 @@ export class DefaultLinkHandler extends LinkHandler {
   activate(history: BrowserHistory): void {
     if (history._hasPushState) {
       this.history = history;
-      DOM.addEventListener('click', this.handler, true);
+      DOM.addEventListener('click', this.handler, false);
     }
   }
 


### PR DESCRIPTION
The `DefaultLinkHandler` attaches a click listener to the document element, which ensures a click on any anchor element activates the router.
Unfortunately, it listens for this event in the `capture` phase, which means no other handlers will ever get a chance to handle the event.
This makes it impossible to intercept the click and execute code before the navigation occurs, e.g. to cancel the navigation or track the click.

The `DefaultLinkHandler` also does not consider whether `preventDefault()` has been called on the event. This makes it impossible to cancel the navigation.

To resolve this, and to be consistent with how links natively work, this pull request:
* Changes `DefaultLinkHandler` to listen for clicks in `bubble` phase instead of `capture` phase.
* Changes `DefaultLinkHandler` to not navigate if `preventDefault()` was called on the click event. 