### PR TITLE
fix(history-browser): Add location.href to replaceState() call

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -188,8 +188,9 @@ export class BrowserHistory extends History {
    */
   setState(key: string, value: any): void {
     let state = Object.assign({}, this.history.state);
+    let { pathname, search, hash } = this.location;
     state[key] = value;
-    this.history.replaceState(state, null, this.location.href);
+    this.history.replaceState(state, null, `${pathname}${search}${hash}`);
   }
 
   /**

--- a/src/index.js
+++ b/src/index.js
@@ -189,7 +189,7 @@ export class BrowserHistory extends History {
   setState(key: string, value: any): void {
     let state = Object.assign({}, this.history.state);
     state[key] = value;
-    this.history.replaceState(state, null, null);
+    this.history.replaceState(state, null, this.location.href);
   }
 
   /**


### PR DESCRIPTION
There is currently a bug in Safari that doesn't properly handle the optional third parameter to the replaceState(state, title, url) function when a <base /> tag is present on the page. This fix explicitly sets the url property to the location.href value.

Thanks to @powerbuoy @huochunpeng and @jwx for helping diagnose this issue!

Closes https://github.com/aurelia/history-browser/issues/34 https://github.com/aurelia/router/issues/574