### PR TITLE
Ignore download links and add router-ignore attribute

### DIFF
--- a/src/link-handler.js
+++ b/src/link-handler.js
@@ -92,6 +92,10 @@ export class DefaultLinkHandler extends LinkHandler {
       return info;
     }
 
+    if (target.hasAttribute('download') || target.hasAttribute('router-ignore')) {
+      return info;
+    }
+
     if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) {
       return info;
     }
@@ -135,7 +139,6 @@ export class DefaultLinkHandler extends LinkHandler {
 
     return !targetWindow ||
       targetWindow === win.name ||
-      targetWindow === '_self' ||
-      (targetWindow === 'top' && win === win.top);
+      targetWindow === '_self';
   }
 }


### PR DESCRIPTION
This makes a small change to the DefaultLinkHandler (src/link-handler). Ignores links with a download attribute. Also ignores links with an attribute called rotuer-ignore. Not sure if this is the best name. In addition I have removed the check (targetWindow === 'top' && win === win.top);. this is because it was clearly meant to be _top not top. I could correct it but I don't want to break any sites which might have been using target="_top" as a workaround. I can put it back in if desired, but I can't see why you would use target="_top" if you wanted the router to handle the link. (Also if this is included then there ought to be a similar check for _parent.)

PS any advice on how to avoid updating the dist folder in the pull request without updating .gitignore would be useful - my GIT knowledge is not great. Or can we add dist to .gitignore?
