### PR TITLE
Fix/navigation with root

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -152,7 +152,7 @@ export class BrowserHistory extends History {
     this.fragment = fragment;
 
     url = fragment;
-    if (this.pushState) {
+    if (this._hasPushState) {
       url = this.root + url;
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -119,13 +119,13 @@ export class BrowserHistory extends History {
   /**
    * Causes a history navigation to occur.
    *
-   * @param fragment The history fragment to navigate to.
+   * @param url URL to navigate to.
    * @param options The set of options that specify how the navigation should occur.
    * @return Promise if triggering navigation, otherwise true/false indicating if navigation occured.
    */
-  navigate(fragment?: string, {trigger = true, replace = false} = {}): Promise|boolean {
-    if (fragment && absoluteUrl.test(fragment)) {
-      this.location.href = fragment;
+  navigate(url?: string, {trigger = true, replace = false} = {}): Promise|boolean {
+    if (url && absoluteUrl.test(url)) {
+      this.location.href = url;
       return true;
     }
 
@@ -133,7 +133,7 @@ export class BrowserHistory extends History {
       return false;
     }
 
-    fragment = this._getFragment(fragment || '');
+    const fragment = this._getFragment(url || '');
 
     if (this.fragment === fragment && !replace) {
       return false;
@@ -141,14 +141,14 @@ export class BrowserHistory extends History {
 
     this.fragment = fragment;
 
-    let url = this.root + fragment;
+    url = this.root + fragment;
 
     // Don't include a trailing slash on the root.
     if (fragment === '' && url !== '/') {
       url = url.slice(0, -1);
     }
 
-    // If pushState is available, we use it to set the fragment as a real URL.
+    // If pushState is available, we use it to set the url as a real URL.
     if (this._hasPushState) {
       url = url.replace('//', '/');
       this.history[replace ? 'replaceState' : 'pushState']({}, DOM.title, url);
@@ -163,7 +163,7 @@ export class BrowserHistory extends History {
     }
 
     if (trigger) {
-      return this._loadUrl(fragment);
+      return this._loadUrl(url);
     }
 
     return true;
@@ -209,18 +209,19 @@ export class BrowserHistory extends History {
     return this.location.hash.substr(1);
   }
 
-  _getFragment(fragment: string, forcePushState?: boolean): string {
-    let root;
-
+  _getFragment(url: string, forcePushState?: boolean): string {
+    let fragment = url;
     if (!fragment) {
       if (this._hasPushState || !this._wantsHashChange || forcePushState) {
         fragment = this.location.pathname + this.location.search;
-        root = this.root.replace(trailingSlash, '');
-        if (!fragment.indexOf(root)) {
-          fragment = fragment.substr(root.length);
-        }
       } else {
         fragment = this._getHash();
+      }
+    }
+    if (this._hasPushState || !this._wantsHashChange || forcePushState) {
+      const root = this.root.replace(trailingSlash, '');
+      if (fragment.indexOf(root) === 0) {
+        fragment = fragment.substr(root.length);
       }
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -151,7 +151,10 @@ export class BrowserHistory extends History {
 
     this.fragment = fragment;
 
-    url = this.root + fragment;
+    url = fragment;
+    if (this.pushState) {
+      url = this.root + url;
+    }
 
     // Don't include a trailing slash on the root.
     if (fragment === '' && url !== '/') {

--- a/src/index.js
+++ b/src/index.js
@@ -124,9 +124,19 @@ export class BrowserHistory extends History {
    * @return Promise if triggering navigation, otherwise true/false indicating if navigation occured.
    */
   navigate(url?: string, {trigger = true, replace = false} = {}): Promise|boolean {
-    if (url && absoluteUrl.test(url)) {
-      this.location.href = url;
-      return true;
+    if (url) {
+      let isOutbound = false;
+      if (absoluteUrl.test(url)) {
+        isOutbound = true;
+      } else if (this._hasPushState && url.indexOf('/') === 0 && url.indexOf(this.root) !== 0) {
+        // Absolute path with a different root
+        isOutbound = true;
+      }
+
+      if (isOutbound) {
+        this.location.href = url;
+        return true;
+      }
     }
 
     if (!this._isActive) {

--- a/test/history.spec.js
+++ b/test/history.spec.js
@@ -10,9 +10,10 @@ describe('browser history', () => {
 
   describe('_getFragment()', () => {
 
-    it('should normalize fragment', () => {
+    it('should normalize fragment from URL', () => {
       var expected = '/admin/user/123';
-      var bh = new BrowserHistory();
+      var bh = new BrowserHistory(new LinkHandler());
+      bh.activate({});
 
       expect(bh._getFragment('admin/user/123')).toBe(expected);
       expect(bh._getFragment('admin/user/123  ')).toBe(expected);
@@ -20,6 +21,28 @@ describe('browser history', () => {
       expect(bh._getFragment('/admin/user/123   ')).toBe(expected);
       expect(bh._getFragment('///admin/user/123')).toBe(expected);
 
+      expect(bh._getFragment('#admin/user/123')).toBe(expected);
+      expect(bh._getFragment('#admin/user/123  ')).toBe(expected);
+      expect(bh._getFragment('#/admin/user/123')).toBe(expected);
+      expect(bh._getFragment('#/admin/user/123   ')).toBe(expected);
+      expect(bh._getFragment('#///admin/user/123')).toBe(expected);
+    });
+
+    it('should normalize fragment when a root is configured', () => {
+      const expected = '/admin/user/123';
+      const bh = new BrowserHistory(new LinkHandler());
+      bh.activate({root: '/root'});
+
+      bh._hasPushState = true;
+      expect(bh._getFragment('admin/user/123')).toBe(expected);
+      expect(bh._getFragment('admin/user/123  ')).toBe(expected);
+      expect(bh._getFragment('/admin/user/123')).toBe(expected);
+      expect(bh._getFragment('/admin/user/123   ')).toBe(expected);
+      expect(bh._getFragment('///admin/user/123')).toBe(expected);
+      expect(bh._getFragment('/root/admin/user/123')).toBe(expected);
+      expect(bh._getFragment('/root///admin/user/123')).toBe(expected);
+
+      bh._hasPushState = false;
       expect(bh._getFragment('#admin/user/123')).toBe(expected);
       expect(bh._getFragment('#admin/user/123  ')).toBe(expected);
       expect(bh._getFragment('#/admin/user/123')).toBe(expected);


### PR DESCRIPTION
This is part of a patch for both `aurelia-history-browser` and `aurelia-router` and contains two bugfixes related to having `root` set to something else than `/`.

# 1. History could not handle outbound links
If `root` is set, eg., to `/app1`, the following link causes a routing error instead of navigating away from the app: `< a href="/app2">Outbound link</a>`.

This is fixed in 407959e.

# 2. History did not handle absolute paths within the app correctly
[The router ignored `root` when creating URLs](https://github.com/aurelia/router/pull/601). This caused all non-default click actions (eg. CMD+Click, Right-click-> "Open in new Tab/Browser", etc.) to navigate to the wrong URL. (And broke links for crawlers.)

But as soon as the router creates correct URLs, history’s lack of proper `root` support causes all navigations to fail. This is fixed in bfad456.