### PR TITLE
feat: add support of data-router-ignore attribute

### DIFF
--- a/src/link-handler.js
+++ b/src/link-handler.js
@@ -92,7 +92,7 @@ export class DefaultLinkHandler extends LinkHandler {
       return info;
     }
 
-    if (target.hasAttribute('download') || target.hasAttribute('router-ignore')) {
+    if (target.hasAttribute('download') || target.hasAttribute('router-ignore') || target.hasAttribute('data-router-ignore')) {
       return info;
     }
 


### PR DESCRIPTION
Add data attribute because it can be dynamically controlled through a binding like `<a data-router-ignore.bind="condition || null"></a>`. This only works on data attribute, not normal attribute. Note `|| null` is required as dataAttributeAccessor only removes the attribute when value is null or undefined.