### PR TITLE
Urls don't match security error fix

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -190,6 +190,9 @@ export class BrowserHistory extends History {
    */
   setState(key: string, value: any): void {
     let state = Object.assign({}, this.history.state);
+    if (this.location.pathname && this.location.pathname.length > 0 ) {
+      this.location.pathname = this.location.pathname.replace('//', '/');
+    }
     let { pathname, search, hash } = this.location;
     state[key] = value;
     this.history.replaceState(state, null, `${pathname}${search}${hash}`);


### PR DESCRIPTION
When the URL has double slashes (example: http://localhost:9000//route?parm1=...), history.replaceState will remove the double slashes. This will produce the following security error because the two URLs don't match anymore:

Unhandled rejection SecurityError: Failed to execute 'replaceState' on 'History': A history state object with URL [...] cannot be created in a document with origin 'http://localhost:9000' and URL [...].

The proposed file changes will fix this.